### PR TITLE
fix mac os 10.13 detection

### DIFF
--- a/src/objc_cpp.h
+++ b/src/objc_cpp.h
@@ -8,13 +8,13 @@
 
 #define IF(type, var, code) type var = code; if(var)
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1013
-    std::string stateToString(CBCentralManagerState state);
-#else
+#if defined(MAC_OS_X_VERSION_10_13)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     std::string stateToString(CBManagerState state);
 #pragma clang diagnostic pop
+#else
+    std::string stateToString(CBCentralManagerState state);
 #endif
 
 

--- a/src/objc_cpp.mm
+++ b/src/objc_cpp.mm
@@ -6,26 +6,7 @@
 //
 #include "objc_cpp.h"
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1013
-std::string stateToString(CBCentralManagerState state)
-{
-    switch(state) {
-        case CBCentralManagerStatePoweredOff:
-            return "poweredOff";
-        case CBCentralManagerStatePoweredOn:
-            return "poweredOn";
-        case CBCentralManagerStateResetting:
-            return "resetting";
-        case CBCentralManagerStateUnauthorized:
-            return "unauthorized";
-        case CBCentralManagerStateUnknown:
-            return "unknown";
-        case CBCentralManagerStateUnsupported:
-            return "unsupported";
-    }
-    return "unknown";
-}
-#else
+#if defined(MAC_OS_X_VERSION_10_13)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
 std::string stateToString(CBManagerState state)
@@ -54,7 +35,25 @@ std::string stateToString(CBManagerState state)
 @interface CBPeripheral (HighSierraSDK)
 @property(readonly, nonatomic) NSUUID* identifier;
 @end
-
+#else
+std::string stateToString(CBCentralManagerState state)
+{
+    switch(state) {
+        case CBCentralManagerStatePoweredOff:
+            return "poweredOff";
+        case CBCentralManagerStatePoweredOn:
+            return "poweredOn";
+        case CBCentralManagerStateResetting:
+            return "resetting";
+        case CBCentralManagerStateUnauthorized:
+            return "unauthorized";
+        case CBCentralManagerStateUnknown:
+            return "unknown";
+        case CBCentralManagerStateUnsupported:
+            return "unsupported";
+    }
+    return "unknown";
+}
 #endif
 
 std::string getUuid(CBPeripheral* peripheral) {


### PR DESCRIPTION
the macro MAC_OS_X_VERSION_10_13 is defined from macOS version 10.13 and onward