### PR TITLE
Set os in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
 	"engines": {
 		"node": ">=6.14.2"
   },
+  "os": [
+    "darwin"
+  ],
   "dependencies": {
     "napi-thread-safe-callback": "0.0.6",
     "noble": "^1.9.1",


### PR DESCRIPTION
Having the os in the `package.json` will prevent the build on other operating systems.