### PR TITLE
Prevent empty localName in advertisement.

### DIFF
--- a/src/ble_manager.mm
+++ b/src/ble_manager.mm
@@ -52,11 +52,11 @@
         p.connectable = [connect boolValue];
     }
     IF(NSString*, dataLocalName, [advertisementData objectForKey:CBAdvertisementDataLocalNameKey]) {
-        p.name = [dataLocalName UTF8String];
+        p.name = std::make_pair([dataLocalName UTF8String], true);
     }
-    if(p.name.empty()) {
+    if(!std::get<1>(p.name)) {
         IF(NSString*, name, [peripheral name]) {
-            p.name = [name UTF8String];
+            p.name = std::make_pair([name UTF8String], true);
         }
     }
     IF(NSNumber*, txLevel, [advertisementData objectForKey:CBAdvertisementDataTxPowerLevelKey]) {

--- a/src/ble_manager.mm
+++ b/src/ble_manager.mm
@@ -60,11 +60,12 @@
         }
     }
     IF(NSNumber*, txLevel, [advertisementData objectForKey:CBAdvertisementDataTxPowerLevelKey]) {
-        p.txPowerLevel = [txLevel intValue];
+        p.txPowerLevel = std::make_pair([txLevel intValue], true);
     }
     IF(NSData*, data, [advertisementData objectForKey:CBAdvertisementDataManufacturerDataKey]) {
         const UInt8* bytes = (UInt8 *)[data bytes];
-        p.manufacturerData.assign(bytes, bytes+[data length]);
+        std::get<0>(p.manufacturerData).assign(bytes, bytes+[data length]);
+        std::get<1>(p.manufacturerData) = true;
     }
     IF(NSDictionary*, dictionary, [advertisementData objectForKey:CBAdvertisementDataServiceDataKey]) {
         for (CBUUID* key in dictionary) {
@@ -73,14 +74,16 @@
                 Data sData;
                 const UInt8* bytes = (UInt8 *)[value bytes];
                 sData.assign(bytes, bytes+[value length]);
-                p.serviceData.push_back(std::make_pair(serviceUuid, sData));
+                std::get<0>(p.serviceData).push_back(std::make_pair(serviceUuid, sData));
             }
         }
+        std::get<1>(p.serviceData) = true;
     }
     IF(NSArray*, services, [advertisementData objectForKey:CBAdvertisementDataServiceUUIDsKey]) {
         for (CBUUID* service in services) {
-            p.serviceUuids.push_back([[service UUIDString] UTF8String]);
+            std::get<0>(p.serviceUuids).push_back([[service UUIDString] UTF8String]);
         }
+        std::get<1>(p.serviceUuids) = true;
     }
 
     int rssi = [RSSI intValue];

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -91,17 +91,28 @@ void Emit::Scan(const std::string& uuid, int rssi, const Peripheral& peripheral)
             advertisment.Set(_s("localName"), _s(std::get<0>(name)));
         }
 
-        advertisment.Set(_s("txPowerLevel"), txPowerLevel);
-        advertisment.Set(_s("manufacturerData"), toBuffer(env, manufacturerData));
-        auto array = serviceData.empty() ? Napi::Array::New(env) : Napi::Array::New(env, serviceData.size());
-        for (size_t i = 0; i < serviceData.size(); i++) {
-            Napi::Object data = Napi::Object::New(env);
-            data.Set(_s("uuid"), _u(serviceData[i].first));
-            data.Set(_s("data"), toBuffer(env, serviceData[i].second));
-            array.Set(i, data);
+        if (std::get<1>(txPowerLevel)) {
+            advertisment.Set(_s("txPowerLevel"), std::get<0>(txPowerLevel));
         }
-        advertisment.Set(_s("serviceData"), array);
-        advertisment.Set(_s("serviceUuids"), toUuidArray(env, serviceUuids));
+
+        if (std::get<1>(manufacturerData)) {
+            advertisment.Set(_s("manufacturerData"), toBuffer(env, std::get<0>(manufacturerData)));
+        }
+
+        if (std::get<1>(serviceData)) {
+            auto array = std::get<0>(serviceData).empty() ? Napi::Array::New(env) : Napi::Array::New(env, std::get<0>(serviceData).size());
+            for (size_t i = 0; i < std::get<0>(serviceData).size(); i++) {
+                Napi::Object data = Napi::Object::New(env);
+                data.Set(_s("uuid"), _u(std::get<0>(serviceData)[i].first));
+                data.Set(_s("data"), toBuffer(env, std::get<0>(serviceData)[i].second));
+                array.Set(i, data);
+            }
+            advertisment.Set(_s("serviceData"), array);
+        }
+
+        if (std::get<1>(serviceUuids)) {
+            advertisment.Set(_s("serviceUuids"), toUuidArray(env, std::get<0>(serviceUuids)));
+        }
         // emit('discover', deviceUuid, address, addressType, connectable, advertisement, rssi);
         args = { _s("discover"), _u(uuid), _s(address), toAddressType(env, addressType), _b(connectable), advertisment, _n(rssi) };
     });

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -87,7 +87,10 @@ void Emit::Scan(const std::string& uuid, int rssi, const Peripheral& peripheral)
     auto serviceUuids = peripheral.serviceUuids;
     mCallback->call([uuid, rssi, address, addressType, connectable, name, txPowerLevel, manufacturerData, serviceData, serviceUuids](Napi::Env env, std::vector<napi_value>& args) {
         Napi::Object advertisment = Napi::Object::New(env);
-        advertisment.Set(_s("localName"), _s(name));
+        if (std::get<1>(name)) {
+            advertisment.Set(_s("localName"), _s(std::get<0>(name)));
+        }
+
         advertisment.Set(_s("txPowerLevel"), txPowerLevel);
         advertisment.Set(_s("manufacturerData"), toBuffer(env, manufacturerData));
         auto array = serviceData.empty() ? Napi::Array::New(env) : Napi::Array::New(env, serviceData.size());

--- a/src/peripheral.h
+++ b/src/peripheral.h
@@ -15,7 +15,7 @@ public:
     std::string address;
     AddressType addressType;
     bool connectable;
-    std::string name;
+    std::pair<std::string, bool> name;
     int txPowerLevel;
     Data manufacturerData;
     std::vector<std::pair<std::string, Data>> serviceData;

--- a/src/peripheral.h
+++ b/src/peripheral.h
@@ -16,8 +16,8 @@ public:
     AddressType addressType;
     bool connectable;
     std::pair<std::string, bool> name;
-    int txPowerLevel;
-    Data manufacturerData;
-    std::vector<std::pair<std::string, Data>> serviceData;
-    std::vector<std::string> serviceUuids;
+    std::pair<int, bool> txPowerLevel;
+    std::pair<Data, bool> manufacturerData;
+    std::pair<std::vector<std::pair<std::string, Data>>, bool> serviceData;
+    std::pair<std::vector<std::string>, bool> serviceUuids;
 };


### PR DESCRIPTION
The current PR prevents emitting an empty localName.

I'm not familiar with Objective-C, please raise any possible issues.